### PR TITLE
Set html head language to French

### DIFF
--- a/templates/template.html
+++ b/templates/template.html
@@ -1,6 +1,6 @@
 {%- set version='8' %}
 <!doctype html>
-<html lang="en" data-bs-theme="dark">
+<html lang="fr" data-bs-theme="dark">
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
This modification allows the browser to better know the language of the site and offers an adaptation and translation depending on the user's region. 
`iframe.html` is not set to french cause all error are in english.

![image](https://github.com/wow0000/friends42/assets/35306710/46564f1d-c2e0-4027-af93-45af30b276ac)
